### PR TITLE
Fix native-reset statement-digest oracle (hidden_coeff_stmt_digest leaks secret coefficients)

### DIFF
--- a/include/pvac/ops/recrypt_hidden_coeff.hpp
+++ b/include/pvac/ops/recrypt_hidden_coeff.hpp
@@ -129,9 +129,15 @@ inline std::array<uint8_t, 32> hidden_coeff_stmt_digest(const HiddenCoeffStmt& s
     h.update("pvac.native.reset.statement", std::strlen("pvac.native.reset.statement"));
     hidden_coeff_acc_bound(h, stmt.bound);
     sha256_acc_u64(h, stmt.alpha.size());
-    for (const auto& alpha : stmt.alpha) {
-        hidden_coeff_acc_fp(h, alpha);
-    }
+    // SECURITY: do not hash the secret coefficient values into this digest.
+    // statement_digest is published in the native-reset transcript, every other input
+    // is public (the bound advertises alpha_bits), and there is no secret salt, so
+    // committing the secret `alpha` here turns statement_digest into a brute-force
+    // oracle for low-entropy coefficients: an observer recomputes SHA256 over public
+    // bound + candidate alpha until it matches. This is the same class of bug as the
+    // R_com plaintext oracle removed in cdc6a52. `alpha` remains bound through the
+    // arithmetic proof's output_digest (out.c / out.beta are derived from alpha), so
+    // hashing the raw values here is redundant for soundness and only leaks them.
     std::array<uint8_t, 32> out{};
     h.finish(out.data());
     return out;

--- a/tests/test_hidden_coeff_leak.cpp
+++ b/tests/test_hidden_coeff_leak.cpp
@@ -1,0 +1,83 @@
+// Regression test for the native-reset statement-digest oracle.
+//
+// Before the fix, hidden_coeff_stmt_digest() hashed the SECRET coefficient vector
+// `alpha` under a public-only salt. Since the digest is published in the transcript
+// and the bound advertises alpha_bits, an observer could brute-force low-entropy
+// coefficients out of the published digest (same class as the R_com plaintext oracle).
+//
+// After the fix, statement_digest is independent of the secret alpha values, so the
+// oracle is closed, while honest transcripts still verify.
+//
+// Build: g++ -std=c++17 -O2 -march=native -I./include tests/test_hidden_coeff_leak.cpp -o build/test_hidden_coeff_leak
+
+#include <pvac/pvac.hpp>
+#include <pvac/ops/recrypt_hidden_coeff.hpp>
+#include <array>
+#include <cstring>
+#include <iostream>
+#include <vector>
+
+using namespace pvac;
+
+// The vulnerable pre-fix digest, kept here only to demonstrate the oracle it enabled.
+static std::array<uint8_t, 32> old_hidden_coeff_stmt_digest(const HiddenCoeffStmt& stmt) {
+    Sha256 h;
+    h.init();
+    h.update("pvac.native.reset.statement", std::strlen("pvac.native.reset.statement"));
+    hidden_coeff_acc_bound(h, stmt.bound);
+    sha256_acc_u64(h, stmt.alpha.size());
+    for (const auto& alpha : stmt.alpha) {
+        hidden_coeff_acc_fp(h, alpha);
+    }
+    std::array<uint8_t, 32> out{};
+    h.finish(out.data());
+    return out;
+}
+
+int main() {
+    int fail = 0;
+
+    HiddenCoeffBound bound{ /*terms*/1, /*alpha_bits*/20, /*row_bits*/40 };
+    std::vector<std::array<uint8_t, 32>> tags(1);
+    tags[0].fill(0x11);
+    auto material = make_hidden_coeff_material(tags, bound);
+
+    // A secret, low-entropy (20-bit) coefficient.
+    uint64_t secret = 0xC0FFE & ((1u << 20) - 1);
+    auto stmt = make_hidden_coeff_stmt({ fp_from_u64(secret) }, bound);
+
+    // 1) The OLD digest is a brute-force oracle: recover the secret from the published digest.
+    auto old_pub = old_hidden_coeff_stmt_digest(stmt);
+    uint64_t recovered = 0;
+    bool old_leaks = false;
+    for (uint64_t cand = 0; cand < (1u << 20); ++cand) {
+        auto g = make_hidden_coeff_stmt({ fp_from_u64(cand) }, bound);
+        if (std::memcmp(old_hidden_coeff_stmt_digest(g).data(), old_pub.data(), 32) == 0) {
+            recovered = cand; old_leaks = true; break;
+        }
+    }
+    std::cout << "[pre-fix] secret recovered from published digest: "
+              << (old_leaks ? "yes" : "no")
+              << " (value=0x" << std::hex << recovered << std::dec << ")\n";
+    if (!old_leaks || recovered != secret) {
+        std::cout << "  (could not reproduce the historical oracle; test setup issue)\n";
+    }
+
+    // 2) The CURRENT digest must NOT depend on the secret alpha values.
+    auto d_secret = hidden_coeff_stmt_digest(stmt);
+    auto other = make_hidden_coeff_stmt({ fp_from_u64((secret ^ 0xABCDE) & ((1u << 20) - 1)) }, bound);
+    auto d_other = hidden_coeff_stmt_digest(other);
+    bool current_leaks = std::memcmp(d_secret.data(), d_other.data(), 32) != 0;
+    std::cout << "[post-fix] statement_digest depends on secret alpha: "
+              << (current_leaks ? "YES (still an oracle)" : "no (oracle closed)") << "\n";
+    if (current_leaks) { std::cout << "FAIL: statement_digest still leaks alpha\n"; ++fail; }
+
+    // 3) Honest transcripts must still verify (functionality preserved).
+    auto transcript = make_native_hidden_coeff_transcript(material, stmt);
+    bool ok = verify_native_hidden_coeff_transcript(material, stmt, transcript);
+    std::cout << "[post-fix] honest transcript round-trips: " << (ok ? "yes" : "no") << "\n";
+    if (!ok) { std::cout << "FAIL: fix broke honest transcript verification\n"; ++fail; }
+
+    std::cout << (fail == 0 ? "\nPASS\n" : "\nFAIL\n");
+    return fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

`hidden_coeff_stmt_digest()` (include/pvac/ops/recrypt_hidden_coeff.hpp) commits the **secret** coefficient vector `alpha` under a public-only salt:

```
statement_digest = SHA256("pvac.native.reset.statement" || bound || |alpha| || alpha[0] || alpha[1] || ...)
```

Every input except `alpha` is public (the `bound` even advertises `alpha_bits`), and there is no secret salt. `statement_digest` is published in the native-reset transcript and also feeds `aggregate_tag`, so an observer who sees only the transcript can brute-force low-entropy coefficients straight out of the digest: recompute SHA256 over the public bound plus a candidate `alpha` until it matches.

This is the same class of bug as the `R_com` plaintext oracle removed in `cdc6a52` (`compute_R_com_base` no longer hashes `R`). The remediation is identical: stop hashing the secret into a publicly checkable digest.

## Fix

Remove the secret `alpha` values from `hidden_coeff_stmt_digest`. `alpha` is still bound through the arithmetic proof's `output_digest` (`out.c` / `out.beta` are derived from `alpha`), so hashing the raw values into `statement_digest` was redundant for soundness and only leaked them.

## Validation

Adds `tests/test_hidden_coeff_leak.cpp`, which:

- reproduces the pre-fix oracle (recovers a 20-bit secret coefficient from the published digest),
- asserts the post-fix `statement_digest` is independent of the secret `alpha` (oracle closed),
- asserts honest transcripts still verify (`make_native_hidden_coeff_transcript` then `verify_native_hidden_coeff_transcript`).

```
[pre-fix] secret recovered from published digest: yes (value=0xc0ffe)
[post-fix] statement_digest depends on secret alpha: no (oracle closed)
[post-fix] honest transcript round-trips: yes
PASS
```

## Note for review

Please confirm `alpha` remains bound via the arithmetic `output_digest` on every path that consumes `statement_digest` / `aggregate_tag` (it is on the paths traced here), matching the reasoning used for the `R_com` fix in `cdc6a52`.
