### PR TITLE
Bind proof.digest to the circuit output (SHA256 hidden-trace forgery); component 1 + spec for the repetition binding

### DIFF
--- a/include/pvac/ops/sha256_hidden_trace.hpp
+++ b/include/pvac/ops/sha256_hidden_trace.hpp
@@ -192,6 +192,7 @@ struct Sha256HiddenTraceBranchProof {
     std::array<uint8_t, 32> challenge = {};
     std::array<uint8_t, 32> response_digest = {};
     std::array<std::array<uint8_t, 32>, 3> commits = {};
+    std::array<Sha256HiddenStateShare, 3> final_post = {};
     std::vector<Sha256HiddenBlockBranch> openings;
     bool message_hidden = false;
     bool schedule_trace = false;
@@ -1328,9 +1329,39 @@ inline std::array<uint8_t, 32> sha256_hidden_trace_branch_challenge(const Sha256
     for (const auto& commit : proof.commits) {
         h.update(commit.data(), commit.size());
     }
+    // Bind the revealed per-branch output shares into the Fiat-Shamir challenge so the
+    // prover cannot pick them after seeing which branch stays closed.
+    for (const auto& share : proof.final_post) {
+        sha256_hidden_acc_state_share(h, share);
+    }
     std::array<uint8_t, 32> out{};
     h.finish(out.data());
     return out;
+}
+
+// Reconstruct the SHA-256 output words from the three branch shares of the final state.
+inline std::array<uint32_t, 8> sha256_hidden_reconstruct_state(const std::array<Sha256HiddenStateShare, 3>& shares) {
+    std::array<uint32_t, 8> out{};
+    for (size_t i = 0; i < 8; ++i) {
+        for (size_t j = 0; j < 32; ++j) {
+            Fp v = fp_add(fp_add(shares[0].word[i].bit[j], shares[1].word[i].bit[j]), shares[2].word[i].bit[j]);
+            if (!sha256_hidden_fp_eq(v, fp_from_u64(0))) {
+                out[i] |= static_cast<uint32_t>(1) << j;
+            }
+        }
+    }
+    return out;
+}
+
+inline bool sha256_hidden_state_share_eq(const Sha256HiddenStateShare& a, const Sha256HiddenStateShare& b) {
+    for (size_t i = 0; i < 8; ++i) {
+        for (size_t j = 0; j < 32; ++j) {
+            if (!sha256_hidden_fp_eq(a.word[i].bit[j], b.word[i].bit[j])) {
+                return false;
+            }
+        }
+    }
+    return true;
 }
 
 inline std::array<uint8_t, 32> sha256_hidden_trace_branch_response(const Sha256HiddenTraceBranchProof& proof) {
@@ -1392,6 +1423,11 @@ inline Sha256HiddenTraceBranchProof make_sha256_hidden_trace_branch_proof(const 
             view.commit = sha256_hidden_block_branch_commit(view);
             by_branch[branch].push_back(view);
         }
+    }
+    // Reveal each branch's final output-state share so the verifier can reconstruct the
+    // digest and bind it. Revealing all three shares only reveals the public output.
+    for (size_t branch = 0; branch < 3; ++branch) {
+        proof.final_post[branch] = by_branch[branch].back().post;
     }
     for (size_t branch = 0; branch < 3; ++branch) {
         Sha256 h;
@@ -1468,6 +1504,18 @@ inline bool verify_sha256_hidden_trace_branch_proof(const Sha256HiddenTraceBranc
         if (out != proof.commits[branch])
             return false;
     }
+    // Bind proof.digest to the traced computation: reconstruct the output from the three
+    // revealed final-state shares and require it to equal the claimed digest. Require each
+    // opened branch's revealed share to match its verified view, so the two opened shares
+    // are the real computation's output shares (only the closed share is unchecked, which
+    // is what the per-repetition soundness of the outer certificate must cover).
+    auto out_state = sha256_hidden_reconstruct_state(proof.final_post);
+    if (sha256_trace_digest_from_state(out_state) != proof.digest)
+        return false;
+    if (!sha256_hidden_state_share_eq(proof.final_post[left], opened[left].back().post))
+        return false;
+    if (!sha256_hidden_state_share_eq(proof.final_post[right], opened[right].back().post))
+        return false;
     return proof.response_digest == sha256_hidden_trace_branch_response(proof);
 }
 

--- a/tests/test_sha256_trace_digest_binding.cpp
+++ b/tests/test_sha256_trace_digest_binding.cpp
@@ -1,0 +1,66 @@
+// Security regression test: verify_sha256_hidden_trace_branch_proof does NOT bind
+// proof.digest to the circuit output.
+//
+// The branch verifier checks gate consistency of the two opened branches, the commits,
+// the challenge, and the response digest -- but never checks that the traced computation
+// actually produces proof.digest. proof.digest is only hashed into the Fiat-Shamir
+// challenge (committed), never verified against the reconstructed output. So an attacker
+// can assert ANY digest with valid branches.
+//
+// This test forges a proof whose circuit hashes "honest message" but that asserts an
+// attacker-chosen digest, and shows verify accepts it. In recrypt_native_cert.hpp this
+// forges `sha.digest == layer.R_com` for an arbitrary R_com (a fake recryption).
+//
+// EXPECTED SECURE BEHAVIOR: verify must reject a proof whose branches do not compute the
+// claimed digest. This test returns non-zero until that binding is added (see PR body).
+//
+// Build: g++ -std=c++17 -O2 -march=native -I./include tests/test_sha256_trace_digest_binding.cpp -o build/test_sha256_trace_digest_binding
+
+#include <pvac/pvac.hpp>
+#include <pvac/ops/sha256_trace.hpp>
+#include <pvac/ops/sha256_hidden_trace.hpp>
+#include <array>
+#include <cstring>
+#include <iostream>
+#include <vector>
+
+using namespace pvac;
+
+int main() {
+    std::vector<uint8_t> real_msg = { 'h','o','n','e','s','t',' ','m','e','s','s','a','g','e' };
+    Sha256Trace trace = make_sha256_trace(real_msg);
+
+    std::array<uint8_t, 32> fake_digest;
+    for (int i = 0; i < 32; ++i) fake_digest[i] = static_cast<uint8_t>(0xA0 + i);  // attacker-chosen
+
+    std::cout << "real digest   : ";
+    for (int i = 0; i < 8; ++i) printf("%02x", trace.digest[i]);
+    std::cout << "...\nforged digest : ";
+    for (int i = 0; i < 8; ++i) printf("%02x", fake_digest[i]);
+    std::cout << "...  (attacker chosen)\n";
+
+    bool accepted = false;
+    for (uint64_t seed = 1; seed < 64 && !accepted; ++seed) {
+        Fp a = fp_from_words(0x9e3779b97f4a7c15ULL * seed, 0x123456789ULL * seed);
+        Fp b = fp_from_words(0xc2b2ae3d27d4eb4fULL * seed, 0x987654321ULL * seed);
+        auto hidden = make_sha256_hidden_trace_proof(trace, a, b);
+        auto P = make_sha256_hidden_trace_branch_proof(hidden);
+        size_t closed = static_cast<size_t>(P.challenge[0]) % 3;
+
+        P.digest = fake_digest;                                       // assert a false digest
+        P.challenge = sha256_hidden_trace_branch_challenge(P);
+        if (static_cast<size_t>(P.challenge[0]) % 3 != closed) continue;
+        P.response_digest = sha256_hidden_trace_branch_response(P);
+
+        if (verify_sha256_hidden_trace_branch_proof(P)) accepted = true;
+    }
+
+    if (accepted) {
+        std::cout << "\nVULNERABLE: verify_sha256_hidden_trace_branch_proof accepted a proof for a\n"
+                     "false digest (branches compute the real hash, proof asserts the fake one).\n"
+                     "FAIL (expected until proof.digest is bound to the reconstructed output)\n";
+        return 1;
+    }
+    std::cout << "\nverify rejected the forged digest -- output binding present. PASS\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary

`verify_sha256_hidden_trace_branch_proof` did not bind `proof.digest` to the traced computation: it checked the opened branches' gate residuals, commits, challenge and response, but never that the circuit's output equals the claimed digest. `proof.digest` was a free field, so an attacker could assert any digest with valid branches (demonstrated in `tests/test_sha256_trace_digest_binding.cpp`). In `recrypt_native_cert.hpp` this forges `sha.digest == layer.R_com` for an arbitrary `R_com`.

## This PR: component 1 (output binding) - implemented and tested

`verify` now reveals all three branches' final output-state shares, reconstructs `output = share0 + share1 + share2`, and requires `sha256_trace_digest_from_state(output) == proof.digest`. It also requires each opened branch's revealed share to match its verified view. The shares are bound into the Fiat-Shamir challenge.

- Honest proofs still verify (8/8).
- The trivial forgery (assert a false digest, leave real shares) is now rejected: the regression test passes.
- `recrypt_native_cert.hpp` still compiles.

## What component 1 does NOT close (kept explicit on purpose)

A grinding forger can still fake the **closed** branch's revealed share so the reconstruction equals a chosen digest, then retry ~3 times until that branch is the one left closed. The closed share is revealed but never checked against its committed computation (the closed branch is not opened). I verified this survives component 1.

## Component 2 (needed for full soundness; spec)

This is inherent to a single (2,3)-ZKBoo repetition and must be closed at the certificate layer:

1. **Bind all repetitions under one challenge.** `recrypt_native_cert.hpp` builds `sha_repetitions` independent branch proofs, each deriving its own `closed = challenge[0] % 3` from its own commits. That lets a forger grind each repetition independently (total cost ~3xreps, linear). Derive every repetition's opened branch from a single Fiat-Shamir challenge over *all* repetitions' commits so grinding costs 3^reps.
2. **Correct the soundness count.** `native_reset_layer_trace_soundness_bits(reps)` returns `reps` (1 bit/rep). A (2,3)-open-2 ZKBoo repetition is worth `log2(3/2) ~= 0.585` bits, so a 128-bit target needs ~219 reps, not 128. Use `floor(reps * log2(3/2))` and require `ceil(target / 0.585)` reps.

Happy to implement component 2 once maintainers confirm the intended transcript change (global challenge shape). I did not include it here because it is a soundness-critical restructuring of the repetition/challenge flow and should be reviewed, not slipped in.
